### PR TITLE
Prevent abuse of internal fiddler proxy

### DIFF
--- a/Grabacr07.KanColleWrapper/KanColleProxy.cs
+++ b/Grabacr07.KanColleWrapper/KanColleProxy.cs
@@ -62,7 +62,7 @@ namespace Grabacr07.KanColleWrapper
 
 		public void Startup(int proxy = 37564)
 		{
-			FiddlerApplication.Startup(proxy, false, true);
+			FiddlerApplication.Startup(proxy, false, true, false);
 			FiddlerApplication.BeforeRequest += this.SetUpstreamProxyHandler;
 
 			SetIESettings("localhost:" + proxy);


### PR DESCRIPTION
Only allow localhost to access fiddler

The original issue here: https://github.com/Grabacr07/KanColleViewer/issues/139
