### PR TITLE
Fixing spelling errors in Counters.cs

### DIFF
--- a/Plugins/Counter/Counters.cs
+++ b/Plugins/Counter/Counters.cs
@@ -64,7 +64,7 @@ namespace Counter
 				.Where(x => x.IsSuccess)
 				.Subscribe(_ => this.Count++);
 
-            this.Text = "Number of scraped equipments";
+            this.Text = "Number of scrapped equipment";
 		}
 	}
 


### PR DESCRIPTION
This changes scraped to scrapped which is the correct term in this context. Additionally, this changes equipments to equipment which should always be singular since equipment is a non-count noun (i.e. it should never be plural).
