### PR TITLE
Fix Logger CSV format

### DIFF
--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -27,7 +27,7 @@ namespace Grabacr07.KanColleWrapper
 		// ReSharper disable once AssignNullToNotNullAttribute
 		public static string LogFolder = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location), "Logs");
 
-	    public enum LogType
+		public enum LogType
 		{
 			BuildItem,
 			BuildShip,
@@ -35,12 +35,12 @@ namespace Grabacr07.KanColleWrapper
 			Materials
 		};
 
-	    public struct LogTypeInfo
+		public struct LogTypeInfo
 		{
 			public string Parameters;
-            public string FileName;
+			public string FileName;
 
-            public LogTypeInfo(string parameters, string fileName)
+			public LogTypeInfo(string parameters, string fileName)
 			{
 				this.Parameters = parameters;
 				this.FileName = fileName;
@@ -216,7 +216,7 @@ namespace Grabacr07.KanColleWrapper
 			{
 				w.Write(DateTime.Now.ToString(this.LogTimestampFormat) + ",");
 				w.Write(string.Join(",", args));
-                w.WriteLine();
+				w.WriteLine();
 			}
 		}
 

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -214,9 +214,7 @@ namespace Grabacr07.KanColleWrapper
 
 			using (var w = File.AppendText(logPath))
 			{
-				w.Write(DateTime.Now.ToString(this.LogTimestampFormat) + ",");
-				w.Write(string.Join(",", args));
-				w.WriteLine();
+				w.WriteLine(DateTime.Now.ToString(this.LogTimestampFormat) + "," + string.Join(",", args));
 			}
 		}
 

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -215,10 +215,7 @@ namespace Grabacr07.KanColleWrapper
 			using (var w = File.AppendText(logPath))
 			{
 				w.Write(DateTime.Now.ToString(this.LogTimestampFormat) + ",");
-				foreach (var arg in args)
-				{
-					w.Write(arg + ",");
-				}				
+				w.Write(string.Join(",", args));
                 w.WriteLine();
 			}
 		}


### PR DESCRIPTION
https://tools.ietf.org/html/rfc4180 states that

> The last field in the record must not be followed by a comma.

which is currently the case and can complicate things (e.g. R's [read.csv](https://stat.ethz.ch/R-manual/R-devel/library/utils/html/read.table.html) function can't parse it by default).

So I replaced foreach with string.Join, is it fine or should it be a loop instead (since ForEach was replaced by foreach previously)?
